### PR TITLE
RemovedInDjango19Warning fix

### DIFF
--- a/form_designer/utils.py
+++ b/form_designer/utils.py
@@ -1,5 +1,11 @@
+try:
+    from importlib import import_module
+except ImportError:
+    # Python < 2.7
+    from django.utils.importlib import import_module
+
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.importlib import import_module
+
 
 def get_class(import_path):
     try:


### PR DESCRIPTION
utils.py:2: RemovedInDjango19Warning: django.utils.importlib will be removed in Django 1.9.
  from django.utils.importlib import import_module